### PR TITLE
feat($marked-renderer-hoist-tags): support `script` and `style` tag in markdown

### DIFF
--- a/core/saika/src/index.js
+++ b/core/saika/src/index.js
@@ -98,6 +98,11 @@ class Saika {
     this.hooks.add('extendMarkedRenderer', fn)
   }
 
+  use(fn) {
+    fn({ Vue })
+    return this
+  }
+
   /**
    * @private
    * @arg {Object} plugin pluginApi

--- a/core/saika/src/plugins/index.js
+++ b/core/saika/src/plugins/index.js
@@ -6,6 +6,7 @@ import markedRendererHeading from './marked-renderer-heading'
 import markedRendererImage from './marked-renderer-image'
 import markedRendererLink from './marked-renderer-link'
 import markedRendererCode from './marked-renderer-code'
+import markedRendererHoistTags from './marked-renderer-hoist-tags'
 
 export default [
   ThemeDefault,
@@ -13,5 +14,6 @@ export default [
   markedRendererHeading,
   markedRendererImage,
   markedRendererLink,
-  markedRendererCode
+  markedRendererCode,
+  markedRendererHoistTags
 ]

--- a/core/saika/src/plugins/marked-renderer-hoist-tags/alternativeComponents.js
+++ b/core/saika/src/plugins/marked-renderer-hoist-tags/alternativeComponents.js
@@ -1,0 +1,13 @@
+export default ({ Vue }) => {
+  Vue.component('v-script', getComponent('script'))
+  Vue.component('v-style', getComponent('style'))
+}
+
+function getComponent(tag) {
+  return {
+    functional: true,
+    render(h, { data, children }) {
+      return h(tag, data, children)
+    }
+  }
+}

--- a/core/saika/src/plugins/marked-renderer-hoist-tags/index.js
+++ b/core/saika/src/plugins/marked-renderer-hoist-tags/index.js
@@ -1,0 +1,22 @@
+import alternativeComponents from './alternativeComponents'
+
+export default {
+  name: 'marked-renderer-hoist-tags',
+  extend: api => {
+    api.use(alternativeComponents)
+
+    api.extendMarkedRenderer(renderer => {
+      const RE = /^<(script|style)(?=(\s|>|$))>/i
+      renderer.html = html => {
+        html = html.trim()
+        if (RE.test(html)) {
+          return html
+            .replace(/^<(script|style)/, '<v-$1')
+            .replace(/<\/(script|style)>$/, '</v-$1>')
+        }
+
+        return html
+      }
+    })
+  }
+}


### PR DESCRIPTION
Also have a new api: `api.use: ({ Vue }) => void`