### PR TITLE
fix: remove all about `toast` for now

### DIFF
--- a/core/src/components/index.js
+++ b/core/src/components/index.js
@@ -6,7 +6,7 @@ import Note from './Note.vue'
 import ImageZoom from './ImageZoom.vue'
 import Badge from './Badge.vue'
 import EditLink from './EditLink.vue'
-import Snippet from './Snippet.vue'
+// import Snippet from './Snippet.vue'
 
 export default ({ Vue }) => {
   Vue.component(PostContent.name, PostContent)
@@ -17,5 +17,5 @@ export default ({ Vue }) => {
   Vue.component(ImageZoom.name, ImageZoom)
   Vue.component(Badge.name, Badge)
   Vue.component(EditLink.name, EditLink)
-  Vue.component(Snippet.name, Snippet)
+  // Vue.component(Snippet.name, Snippet)
 }

--- a/core/src/plugins/marked-renderer-code/index.js
+++ b/core/src/plugins/marked-renderer-code/index.js
@@ -1,13 +1,13 @@
 import marked from '../../utils/marked'
 import parseCodeOptions from '../../utils/parseCodeOptions'
-import CopyCodeButton from './CopyCodeButton.vue'
+// import CopyCodeButton from './CopyCodeButton.vue'
 
 export default {
   name: 'marked-renderer-code',
   extend: api => {
-    api.use(({ Vue }) => {
-      Vue.use(CopyCodeButton)
-    })
+    // api.use(({ Vue }) => {
+    //   Vue.use(CopyCodeButton)
+    // })
 
     api.hook('extendMarkedRenderer', renderer => {
       // `v-pre` Disable template interpolation in code
@@ -53,9 +53,9 @@ export default {
           res += `<div class="code-mask">${codeMask}</div>`
         }
 
-        if (lang) {
-          res += `<CopyCodeButton code="${encodeURI(code)}" />`
-        }
+        // if (lang) {
+        //   res += `<CopyCodeButton code="${encodeURI(code)}" />`
+        // }
 
         return `<div data-lang="${lang || ''}" class="pre-wrapper">${res}</div>`
       }

--- a/website/public/reference/built-in-components.md
+++ b/website/public/reference/built-in-components.md
@@ -120,6 +120,10 @@ Example:
 - Feature 4 <Badge type="error">Error</Badge>
 - Feature 5 <Badge color="magenta">Custom Color</Badge>
 
+---
+
+<details><summary>Disable for now</summary>
+
 ## Snippet <Badge content="Saika 2.10.0+" />
 
 Display a snippet of copyable code for the command line
@@ -142,8 +146,10 @@ Example:
 <Snippet text="npm install saika" :prompt="false" />
 ```
 
-<Snippet text="npm install saika" />
+<!-- <Snippet text="npm install saika" />
 
 <Snippet :text="['npm install saika', 'yarn add saika']" />
 
-<Snippet text="npm install saika" :prompt="false" />
+<Snippet text="npm install saika" :prompt="false" /> -->
+
+</details>


### PR DESCRIPTION
includes `snippet` component and `copy code` function